### PR TITLE
Remove `matrix-field` class from field type settings

### DIFF
--- a/src/templates/_components/fields/OptimizedImages_settings.twig
+++ b/src/templates/_components/fields/OptimizedImages_settings.twig
@@ -52,7 +52,7 @@
     <div class="input ltr">
         <input type="hidden" name="variants" value="">
 
-        <div class="matrix matrix-field" id="{{ id }}" style="position: relative;">
+        <div class="matrix" id="{{ id }}" style="position: relative;">
             <div class="io-menu-clone" style="display: none;">
                 <div class="menu">
                     <ul class="padded">


### PR DESCRIPTION
Breaks plugins that rely on that class _only_ being used on actual Matrix fields, like Spoon. Its undocumented but that class was added by P&T so that I could only target core Matrix fields.

Fixes #94 and https://github.com/angell-co/Spoon/issues/15