### PR TITLE
Check for empty string ("") in variant format when getting final format

### DIFF
--- a/src/services/OptimizedImages.php
+++ b/src/services/OptimizedImages.php
@@ -88,7 +88,7 @@ class OptimizedImages extends Component
                 $retinaSizes = $variant['retinaSizes'];
             }
             foreach ($retinaSizes as $retinaSize) {
-                $finalFormat = $variant['format'] ?? $asset->getExtension();
+                $finalFormat = !empty($variant['format']) ? $variant['format'] : $asset->getExtension();
                 // Only try the transform if it's possible
                 if (Image::canManipulateAsImage($finalFormat)
                     && Image::canManipulateAsImage($asset->getExtension())


### PR DESCRIPTION
It seems variant format "auto" can end up being stored as an empty string instead of `null`, and if so is passed on as file format (in `$finalFormat`) not eligible for manipulation. Could be related to #103 and #107. 