### PR TITLE
Add Super Table conditional for field

### DIFF
--- a/src/fields/OptimizedImages.php
+++ b/src/fields/OptimizedImages.php
@@ -26,6 +26,8 @@ use yii\base\InvalidConfigException;
 use yii\db\Exception;
 use yii\db\Schema;
 
+use verbb\supertable\fields\SuperTableField;
+
 /** @noinspection MissingPropertyAnnotationsInspection */
 
 /**
@@ -221,7 +223,7 @@ class OptimizedImages extends Field
     public function getSettingsHtml()
     {
         $namespace = Craft::$app->getView()->getNamespace();
-        if (strpos($namespace, Matrix::class) !== false) {
+        if (strpos($namespace, Matrix::class) !== false || strpos($namespace, SuperTableField::class) !== false) {
             // Render an error template, since the field only works when attached to an Asset
             try {
                 return Craft::$app->getView()->renderTemplate(


### PR DESCRIPTION
This PR addresses [this issue](https://github.com/verbb/super-table/issues/205) which throws an error when a field is added to a Super Table field. After checking what's expected behaviour with Matrix, seems like its an easy fix.

This is duplicating the experience with how Matrix handles the same scenario - ie, it shows `OptimizedImages fields only work when added to an Asset Volume's layout.` when trying to add the field to a Matrix.

I'm not sure how you feel about adding third-party references in your plugin as cases - but let me know if you have an alternative!