### PR TITLE
fix(form): duplicate id

### DIFF
--- a/src/templates/_components/fields/OptimizedImages_settings.twig
+++ b/src/templates/_components/fields/OptimizedImages_settings.twig
@@ -14,6 +14,7 @@
 #}
 
 {% import "_includes/forms" as forms %}
+{% from 'image-optimize/_includes/macros' import checkboxGroupField %}
 
 {% do view.registerAssetBundle("nystudio107\\imageoptimize\\assetbundles\\imageoptimize\\ImageOptimizeAsset") %}
 {% do view.registerAssetBundle("nystudio107\\imageoptimize\\assetbundles\\optimizedimagesfield\\OptimizedImagesFieldAsset") %}
@@ -210,7 +211,7 @@
                                 {% if field.variants[loop.index0]['retinaSizes'] is defined and field.variants[loop.index0]['retinaSizes'] |length %}
                                     {% set retinaValues = field.variants[loop.index0]['retinaSizes'] %}
                                 {% endif %}
-                                {{ forms.checkboxGroupField({
+                                {{ checkboxGroupField({
                                     label: "Retina Sizes"|t('image-optimize'),
                                     instructions: "The additional retina sizes that should be created for this variant."|t('image-optimize'),
                                     id: 'variants-' ~ loop.index0 ~ '-retinaSizes',

--- a/src/templates/_includes/checkboxGroup.twig
+++ b/src/templates/_includes/checkboxGroup.twig
@@ -1,0 +1,42 @@
+{# @var craft \craft\web\twig\variables\CraftVariable #}
+{#
+/**
+ * Image Optimize plugin for Craft CMS 3.x
+ *
+ * Custom `checkboxGroup` input. Checkbox group doesn't allow access to checkbox, therefore we can't control the ID.
+ * For this reason we use create the a custom `checkboxGroup` that will use Craft native checkboxes.
+ *
+ * @author    nystudio107
+ * @copyright Copyright (c) 2017 nystudio107
+ * @link      https://nystudio107.com
+ * @package   ImageOptimize
+ * @since     1.5.6
+ */
+#}
+
+{% import "_includes/forms" as forms %}
+
+{% if name is defined and name %}
+    <input type="hidden" name="{{ name }}" value="">
+{% endif -%}
+
+{%- set options = (options is defined ? options : []) %}
+{%- set values = (values is defined ? values : []) %}
+{%- set name = (name is defined and name ? name~'[]' : null) %}
+
+<div class="checkbox-group"
+        {%- if block('attr') is defined %} {{ block('attr') }}{% endif %}>
+    {%- for key, option in options %}
+        {%- if option is not iterable %}
+            {%- set option = {label: option, value: key} %}
+        {%- endif %}
+        <div>
+            {{ forms.checkbox({
+                id:       (id is defined ? id ~ '-' ~ key : null),
+                name:      name,
+                checked:   (option.value is defined and option.value in values),
+                autofocus: (autofocus is defined and autofocus and loop.first and not craft.app.request.isMobileBrowser(true))
+            }|merge(option)) }}
+        </div>
+    {%- endfor %}
+</div>

--- a/src/templates/_includes/macros.twig
+++ b/src/templates/_includes/macros.twig
@@ -6,3 +6,13 @@
         {{ false }}
     {%- endif -%}
 {%- endmacro %}
+
+{% macro checkboxGroupField(config) %}
+    {% import "_includes/forms" as forms %}
+    {% import _self as macros %}
+    {{ forms.field(config, macros.checkboxGroup(config)) }}
+{% endmacro %}
+
+{% macro checkboxGroup(config) %}
+    {% include "image-optimize/_includes/checkboxGroup" with config only %}
+{% endmacro %}


### PR DESCRIPTION
This is one way to address #143. There are multiple ways to approach this problem.

First one would be to update the RegEx pattern and match the Craft generated id. I skipped this solution because of consistency, as this field would have a unique pattern. Furthermore, updating the regex only for this field would introduce further confusion and raise question.

Second solution would be to manually list checkboxes directly inside `OptimizedImages_settings.twig`. I ignored this options as it would break the code style, introduce complexity.

Finally, I choose the third option and that is to create _(copy)_ a custom `checkboxGroupField` and inside generate a custom `id` for each checkbox. There is still full control, even if Craft decides to update something the custom field uses there native checkboxes it only sends it a custom id.

Here is an example how the new IDs look:

```
// Variant 1
types-nystudio107-imageoptimize-fields-OptimizedImages-variants-0-retinaSizes-1
types-nystudio107-imageoptimize-fields-OptimizedImages-variants-0-retinaSizes-2

// Variant 4
types-nystudio107-imageoptimize-fields-OptimizedImages-variants-3-retinaSizes-1
types-nystudio107-imageoptimize-fields-OptimizedImages-variants-3-retinaSizes-2
```

Fixes #143