### PR TITLE
Add commandOutputFileName option.

### DIFF
--- a/src/services/Optimize.php
+++ b/src/services/Optimize.php
@@ -563,12 +563,20 @@ class Optimize extends Component
                     .escapeshellarg($tempPath)
                     .' ';
             }
+            // Output to a file name
+            $outputFileName = '';
+            if (!empty($thisProcessor['commandOutputFileName']) && $thisProcessor['commandOutputFileName']) {
+                $outputFileName = ' '
+                    .escapeshellarg($tempPath)
+                    .' ';
+            }
             // Build the command to execute
             $cmd =
                 $thisProcessor['commandPath']
                 .$commandOptions
                 .$outputFileFlag
-                .escapeshellarg($tempPath);
+                .escapeshellarg($tempPath)
+                .$outputFileName;
             // Execute the command
             $shellOutput = $this->executeShellCommand($cmd);
             Craft::info($cmd."\n".$shellOutput, __METHOD__);
@@ -640,6 +648,13 @@ class Optimize extends Component
                     .escapeshellarg($outputPath)
                     .' ';
             }
+            // Write to a file if necessary for this variantCreator
+            $outputFileName = '';
+            if (!empty($variantCreatorCommand['commandOutputFileName']) && $variantCreatorCommand['commandOutputFileName']) {
+                $outputFileName = ' '
+                    .escapeshellarg($outputPath)
+                    .' ';
+            }
             // Get the quality setting of this transform
             $commandQualityFlag = '';
             if (!empty($variantCreatorCommand['commandQualityFlag'])) {
@@ -655,7 +670,8 @@ class Optimize extends Component
                 .$commandOptions
                 .$commandQualityFlag
                 .$outputFileFlag
-                .escapeshellarg($tempPath);
+                .escapeshellarg($tempPath)
+                .$outputFileName;
             // Execute the command
             $shellOutput = $this->executeShellCommand($cmd);
             Craft::info($cmd."\n".$shellOutput, __METHOD__);


### PR DESCRIPTION
Hello,

My hosting setup does not allow the addition of new packages, but imagemagick exists and I wanted to create webp images. So I added the ability to use convert from imagemagick.

`convert` is weird and requires the path to write to at the end of the command, rather then a file flag like others. So I added that functionality.

This adds a new option to imageProcessors and imageVariantCreators
that when set to true writes to output filename to the end of the command.

This allows you to use convert from imagemagick and other libraries that
require a filename to write to at the end of the command, rather then a
output flag.

Example

    'imageVariantCreators' => [
        // webp variant creator
        'convert' => [
            'commandPath' => '/usr/local/bin/convert',
            'commandOptions' => '-define webp:lossless=false',
            'commandOutputFileFlag' => '',
            'commandQualityFlag' => '-quality',
            'commandOutputFileName' => true,
            'imageVariantExtension' => 'webp',
        ],
    ]