### PR TITLE
Updating transform format logic

### DIFF
--- a/src/services/Optimize.php
+++ b/src/services/Optimize.php
@@ -180,7 +180,7 @@ class Optimize extends Component
             }
             // Normalize the extension to lowercase, for some transform methods that require this
             if (!empty($transform) && !empty($finalFormat)) {
-                $transform['format'] = strtolower($finalFormat);
+                $transform['format'] = $transform['format'] === null ? null : strtolower($finalFormat);
             }
             // Generate an image transform url
             $url = ImageOptimize::$plugin->transformMethod->getTransformUrl(


### PR DESCRIPTION
### Description
Fixes issue when using `asset.getUrl({ })` with Imgix, where `format` would be coerced to the image's extension format, when it should have been left as `null`.


### Related issues
Fixes #226 