### PR TITLE
Update docs: call controller in Craft 3 compatible syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@
 
 ## 1.6.12 - 2020.03.21
 ### Added
-* Added the `createAsset` console command for regenerating the responsive image variants for a single Asset ID
+* Added the `create-asset` console command for regenerating the responsive image variants for a single Asset ID
 
 ### Changed
 * Generated image URLs that have no file format extension are now properly displayed in the GUI (an issue mostly with serverless Sharp)

--- a/docs/docs/Using.md
+++ b/docs/docs/Using.md
@@ -86,10 +86,10 @@ You can combine the two, and narrow things down to a specific volume and a speci
 php craft image-optimize/optimize/create myVolumeHandle --field=myFieldHandle
 ```
 
-If you want to generate only responsive image variants for a specific Asset, you can do that by specifying the Asset ID via the console command `createAsset`:
+If you want to generate only responsive image variants for a specific Asset, you can do that by specifying the Asset ID via the console command `create-asset`:
 
 ```
-php craft image-optimize/optimize/createAsset 101
+php craft image-optimize/optimize/create-asset 101
 ```
 
 ### Forcing Image Variant Creation
@@ -111,7 +111,7 @@ php craft image-optimize/optimize/create myVolumeHandle --field=myFieldHandle --
 ```
 
 ```
-php craft image-optimize/optimize/createAsset 101 --force
+php craft image-optimize/optimize/create-asset 101 --force
 ```
 
 etc.


### PR DESCRIPTION
### Description
When executing the command for transforming single asset ran into "Unknown command"-error:

```bash
Unknown command: image-optimize/optimize/createAsset

Did you mean "image-optimize/optimize/create-asset"?
Caused by: Exception 'yii\base\InvalidRouteException' with message 'Unable to resolve the request: image-optimize/optimize/createAsset'
```

Since Craft 3 / Yii2 console controllers are resolved through kebab-naming syntax. Updated the docs to reflect this. 
