### PR TITLE
Stops console information from getting truncated

### DIFF
--- a/src/console/controllers/OptimizeController.php
+++ b/src/console/controllers/OptimizeController.php
@@ -48,8 +48,7 @@ class OptimizeController extends Controller
     // =========================================================================
 
     /**
-     * Create all of the OptimizedImages Field variants by creating all of the
-     * responsive image variant transforms
+     * Create all of the OptimizedImages Field variants by creating all of the responsive image variant transforms
      *
      * @param string|null $volumeHandle
      *


### PR DESCRIPTION
Currently cuts off after the first line when running ./craft on the CLI, as it doesn't pick up the second line

### Description



### Related issues
