### PR TITLE
Bring annotated property names in line with PHPDocs examples

### DIFF
--- a/src/ImageOptimize.php
+++ b/src/ImageOptimize.php
@@ -68,10 +68,10 @@ use yii\base\InvalidConfigException;
  * @package   ImageOptimize
  * @since     1.0.0
  *
- * @property OptimizeService         optimize
- * @property PlaceholderService      placeholder
- * @property OptimizedImagesService  optimizedImages
- * @property ImageTransformInterface transformMethod
+ * @property OptimizeService         $optimize
+ * @property PlaceholderService      $placeholder
+ * @property OptimizedImagesService  $optimizedImages
+ * @property ImageTransformInterface $transformMethod
  * @property Settings                $settings
  * @method   Settings                getSettings()
  */


### PR DESCRIPTION
### Description
Bring annotated property names in line with PHPDocs examples. Also brings consistency with `$settings` annotation.

See https://docs.phpdoc.org/latest/guide/references/phpdoc/tags/property-read.html#property-property-read-property-write and 
<img width="556" alt="image" src="https://user-images.githubusercontent.com/7550540/103892776-70ce3c00-50ec-11eb-9050-aff1a77d940e.png">


