### PR TITLE
Refactor WebP support check

### DIFF
--- a/src/services/Optimize.php
+++ b/src/services/Optimize.php
@@ -210,7 +210,7 @@ class Optimize extends Component
             if (ImageHelper::canManipulateAsImage($asset->getExtension())) {
                 $transform = new AssetTransform([
                     'width' => $event->width,
-		    'height' => $event->height,
+                    'height' => $event->height,
                     'interlace' => 'line',
                 ]);
                 /** @var ImageTransform $transformMethod */
@@ -522,6 +522,23 @@ class Optimize extends Component
         return $result;
     }
 
+    /**
+     * Returns whether `.webp` is a format supported by the server
+     *
+     * @return bool
+     */
+    public function serverSupportsWebP(): bool
+    {
+        $variantCreators = $this->getActiveVariantCreators();
+        foreach ($variantCreators as $variantCreator) {
+            if ($variantCreator['creator'] === 'cwebp' && $variantCreator['installed']) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     // Protected Methods
     // =========================================================================
 
@@ -530,7 +547,6 @@ class Optimize extends Component
      * @param Asset          $asset
      * @param Image          $image
      */
-
     protected function applyFiltersToImage(AssetTransform $transform, Asset $asset, Image $image)
     {
         $settings = ImageOptimize::$plugin->getSettings();

--- a/src/variables/ImageOptimizeVariable.php
+++ b/src/variables/ImageOptimizeVariable.php
@@ -66,15 +66,7 @@ class ImageOptimizeVariable extends ManifestVariable
      */
     public function serverSupportsWebP(): bool
     {
-        $result = false;
-        $variantCreators = ImageOptimize::$plugin->optimize->getActiveVariantCreators();
-        foreach ($variantCreators as $variantCreator) {
-            if ($variantCreator['creator'] === 'cwebp' && $variantCreator['installed']) {
-                $result = true;
-            }
-        }
-
-        return $result;
+        return ImageOptimize::$plugin->optimize->serverSupportsWebP();
     }
 
     /**


### PR DESCRIPTION
### Description
The check to see whether the server supports WebP is currently encapsulated within Twig-exposed code (`./src/variables/ImageOptimizeVariable.php`). 

In our Craft CMS projects we almost always use custom PHP code through setting up Modules. Extracting the support check to the Optimize Service class allows easy use of that check in PHP code as well, vs just in templates.