### PR TITLE
Fix PHP < 7.3 throwing errors with `array_merge` and a trailing comma

### DIFF
--- a/src/services/Optimize.php
+++ b/src/services/Optimize.php
@@ -272,7 +272,7 @@ class Optimize extends Component
         $vars = array_merge([
             'scriptSrc' => 'https://cdnjs.cloudflare.com/ajax/libs/lazysizes/5.3.0/lazysizes.min.js',
             ],
-            $variables,
+            $variables
         );
         $content = PluginTemplateHelper::renderPluginTemplate(
             'frontend/lazysizes-fallback-js',
@@ -283,7 +283,7 @@ class Optimize extends Component
         if ($scriptAttrs !== null) {
             $attrs = array_merge([
                 ],
-                $scriptAttrs,
+                $scriptAttrs
             );
             $content = Html::tag('script', $content, $scriptAttrs);
         }
@@ -307,7 +307,7 @@ class Optimize extends Component
         $vars = array_merge([
             'scriptSrc' => 'https://cdnjs.cloudflare.com/ajax/libs/lazysizes/5.3.0/lazysizes.min.js',
         ],
-            $variables,
+            $variables
         );
         $content = PluginTemplateHelper::renderPluginTemplate(
             'frontend/lazysizes-js',
@@ -318,7 +318,7 @@ class Optimize extends Component
         if ($scriptAttrs !== null) {
             $attrs = array_merge([
             ],
-                $scriptAttrs,
+                $scriptAttrs
             );
             $content = Html::tag('script', $content, $scriptAttrs);
         }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1221575/107867764-927fc780-6ed1-11eb-97db-2d3d29de19e3.png)
