### PR TITLE
Async variant creation in Asset::SCENARIO_MOVE (Craft >= 3.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.6.39 - UNRELEASED
 ### Changed
 * Updated the buildchain to use Node 16
+* Create variants via queue when an asset is moved in Craft >=3.7.1
 
 ## 1.6.38 - 2021.11.18
 ### Fixed

--- a/src/fields/OptimizedImages.php
+++ b/src/fields/OptimizedImages.php
@@ -217,9 +217,16 @@ class OptimizedImages extends Field
         if ($asset !== null && $asset instanceof Asset && $asset->id !== null) {
             // If this element is propagating, we don't need to redo the image saving for each site
             if (!$asset->propagating) {
-                // If the scenario is Asset::SCENARIO_FILEOPS treat it as a new asset
+                // If the scenario is Asset::SCENARIO_FILEOPS or Asset::SCENARIO_MOVE (if using Craft > v3.7.1) treat it as a new asset
                 $scenario = $asset->getScenario();
-                if ($isNew || $scenario === Asset::SCENARIO_FILEOPS ) {
+
+				$supportsMoveScenario = version_compare(
+						Craft::$app->getVersion(),
+						'3.7.1',
+						'>='
+					) === true;
+
+                if ($isNew || $scenario === Asset::SCENARIO_FILEOPS || ($supportsMoveScenario && $scenario === Asset::SCENARIO_MOVE) ) {
                     /**
                      * If this is a newly uploaded/created Asset, we can save the variants
                      * via a queue job to prevent it from blocking

--- a/src/fields/OptimizedImages.php
+++ b/src/fields/OptimizedImages.php
@@ -220,11 +220,11 @@ class OptimizedImages extends Field
                 // If the scenario is Asset::SCENARIO_FILEOPS or Asset::SCENARIO_MOVE (if using Craft > v3.7.1) treat it as a new asset
                 $scenario = $asset->getScenario();
 
-				$supportsMoveScenario = version_compare(
-						Craft::$app->getVersion(),
-						'3.7.1',
-						'>='
-					) === true;
+		$supportsMoveScenario = version_compare(
+			Craft::$app->getVersion(),
+			'3.7.1',
+			'>='
+		) === true;
 
                 if ($isNew || $scenario === Asset::SCENARIO_FILEOPS || ($supportsMoveScenario && $scenario === Asset::SCENARIO_MOVE) ) {
                     /**


### PR DESCRIPTION
### Description
Craft 3.7.1 introduced the `Asset::SCENARIO_MOVE` scenario. 
Up until now, only `Asset::SCENARIO_FILEOPS` causes `craft-imageoptimize` to process variant creation via queue. All other scenarios result in instant variant creation. 

The change in this PR checks for Craft >= 3.7.1 in `afterElementSave()` of the `OptimizedImages` custom field and treats `Asset::SCENARIO_MOVE` exactly as `Asset::SCENARIO_FILEOPS` to avoid blocking the UI e.g. when a temporary upload was made to an asset field to an entry where the asset is moved to a different directory when saving the entry.