### PR TITLE
Only update variants for existing asset if the image has been manipulated

### DIFF
--- a/src/fields/OptimizedImages.php
+++ b/src/fields/OptimizedImages.php
@@ -236,14 +236,16 @@ class OptimizedImages extends Field
                     ImageOptimize::$plugin->optimizedImages->resaveAsset($asset->id);
                 } else {
                     /**
-                     * If it's not a newly uploaded/created Asset, they may have edited
-                     * the image with the ImageEditor, so we need to update the variants
-                     * immediately, so the AssetSelectorHud displays the new images
+                     * If it's not a newly uploaded/created Asset, check to see if the image
+                     * itself is being updated (via the ImageEditor). If so, update the
+                     * variants immediately so the AssetSelectorHud displays the new images
                      */
-                    try {
-                        ImageOptimize::$plugin->optimizedImages->updateOptimizedImageFieldData($this, $asset);
-                    } catch (Exception $e) {
-                        Craft::error($e->getMessage(), __METHOD__);
+                    if (Craft::$app->getRequest()->getPathInfo() === 'actions/assets/save-image') {
+                        try {
+                            ImageOptimize::$plugin->optimizedImages->updateOptimizedImageFieldData($this, $asset);
+                        } catch (Exception $e) {
+                            Craft::error($e->getMessage(), __METHOD__);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Description

Currently, when editing an existing asset, pressing _Save_ triggers a call to `OptimizeImages::updateOptimizedImageFieldData()` inline with the browser request—even if the editor only updated the title or a field value, and didn't manipulate the existing image at all. For assets that are configured to yield a lot of variants, this can cause the request to hang for quite a while and become a productivity bottleneck for the editor.

This PR adds a check, to make sure an asset save was caused by an image manipulation, before firing the variant update process. It does this by checking that the current request is for the `assets/save-image` action fired by the `AssetImageEditor`.
