### PR TITLE
Fix performance issue while creating a draft

### DIFF
--- a/src/ImageOptimize.php
+++ b/src/ImageOptimize.php
@@ -301,7 +301,6 @@ class ImageOptimize extends Plugin
                 $variable = $event->sender;
                 $variable->set('imageOptimize', [
                     'class' => ImageOptimizeVariable::class,
-                    'viteService' => $this->vite,
                 ]);
             }
         );


### PR DESCRIPTION
### Description
We have the problem that the whole Craft CMS instance becomes unresponsive when a user creates a draft.

I found two plugins that cause the problem. `seomatic` and `image-optimize`. 
Removing the `viteService` from the `CraftVariable` event is resolving the issue for this plugin.

Also see: https://github.com/nystudio107/craft-seomatic/issues/1071