### PR TITLE
Remove old craft generated temp files

### DIFF
--- a/src/ImageOptimize.php
+++ b/src/ImageOptimize.php
@@ -351,6 +351,8 @@ class ImageOptimize extends Plugin
                     $event
                 );
                 if ($tempPath) {
+                    // Remove the old Craft generated transform that's still sitting in the temp directory.
+                    @unlink($event->tempPath);
                     $event->tempPath = $tempPath;
                 }
             }


### PR DESCRIPTION
### Description
Craft temporary directory gets filled up with image files when ImageOptimize plugin is enabled. 

After some debugging, it looks like Craft creates a copy of the image in the temp directory before firing off the `EVENT_TRANSFORM_IMAGE` event, and sends the path to the file as the `tempPath` property of the event object. Craft then pulls the path back out after any attached eventhandlers have done their thing, and finishes up any house cleaning tasks.

The issue is that ImageOptimize creates its own file in the temp directory, and replaces the `tempPath` property with the updated path. Craft then uses the path generated by the plugin for the rest of the process. The old temp file that was created by Craft is orphaned and fills up the temp directory.

This PR is to make sure that the orphaned temp files get deleted so they don't stick around.

