### PR TITLE
[v4] There should be an alt attribute on images if it's specified as empty

### DIFF
--- a/src/models/ImgTag.php
+++ b/src/models/ImgTag.php
@@ -106,8 +106,13 @@ class ImgTag extends BaseImageTag
         if ($this->loadingStrategy !== 'eager') {
             $attrs = $this->swapLazyLoadAttrs($this->loadingStrategy, $this->placeholder, $attrs);
         }
-        // Remove any empty attributes
-        $attrs = array_filter($attrs);
+        
+        // Remove any empty attributes except the alt attribute
+        $attrs = array_filter($attrs, function($value, $key) {
+            // Keep the 'alt' attribute even if it's empty
+            return $key === 'alt' || !empty($value);
+        }, ARRAY_FILTER_USE_BOTH);
+
         // Render the tag
         $tag = Html::tag('img', '', $attrs);
 

--- a/src/models/PictureTag.php
+++ b/src/models/PictureTag.php
@@ -174,8 +174,13 @@ class PictureTag extends BaseImageTag
         if ($this->loadingStrategy !== 'eager') {
             $attrs = $this->swapLazyLoadAttrs($this->loadingStrategy, $this->placeholder, $attrs);
         }
-        // Remove any empty attributes
-        $attrs = array_filter($attrs);
+
+        // Remove any empty attributes except the alt attribute
+        $attrs = array_filter($attrs, function($value, $key) {
+            // Keep the 'alt' attribute even if it's empty
+            return $key === 'alt' || !empty($value);
+        }, ARRAY_FILTER_USE_BOTH);
+        
         // Render the tag
         $content .= Html::tag('img', '', $attrs);
         // Handle the <picture> tag


### PR DESCRIPTION
### Description
Screen readers announce the filename of decorative images if the alt tag is not present. The plug-in should allow empty alt tags.

This is the fix for v4 that fixes #411


### Related issues
