### PR TITLE
Fix `srcset` width filtering

### DIFF
--- a/src/models/OptimizedImage.php
+++ b/src/models/OptimizedImage.php
@@ -618,8 +618,7 @@ class OptimizedImage extends Model
         if (empty($this->variantSourceWidths)) {
             return $subset;
         }
-        // Sort the arrays by numeric key
-        ksort($set, SORT_NUMERIC);
+        // Sort the source widths by numeric key
         sort($this->variantSourceWidths, SORT_NUMERIC);
         foreach ($this->variantSourceWidths as $variantSourceWidth) {
             $match = false;


### PR DESCRIPTION
Spent far too long troubleshooting what was going on in a site that was working fine before https://github.com/nystudio107/craft-imageoptimize/issues/407, and outputting the wrong image sizes after updating. 

This PR removes the sorting of the `set` of srcsets to be filtered, which was causing them to get out of sync with the `variantSourceWidths`.

Here’s an example with `2x` retina size selected and sizes `[400, 500]`, to demonstrate the bug:

```
set: [400, 800, 500, 1000]
variantSourceWidths: [400, 400, 500, 500]
```

Becomes:

```
set: [400, 500, 800, 1000]
variantSourceWidths: [400, 400, 500, 500]
```