### PR TITLE
Fix srcsetWidth methods to properly handle retina variants

### DIFF
--- a/src/models/OptimizedImage.php
+++ b/src/models/OptimizedImage.php
@@ -189,7 +189,7 @@ class OptimizedImage extends Model
      */
     public function srcsetWidth(int $width, bool $dpr = false): string
     {
-        $subset = $this->getSrcsetSubsetArray($this->optimizedImageUrls, $width, 'width');
+        $subset = $this->getSrcsetSubsetArray($this->optimizedImageUrls, $width, 'width', $dpr);
 
         return Template::raw($this->getSrcsetFromArray($subset, $dpr));
     }
@@ -206,7 +206,7 @@ class OptimizedImage extends Model
      */
     public function srcsetMinWidth(int $width, bool $dpr = false): string
     {
-        $subset = $this->getSrcsetSubsetArray($this->optimizedImageUrls, $width, 'minwidth');
+        $subset = $this->getSrcsetSubsetArray($this->optimizedImageUrls, $width, 'minwidth', $dpr);
 
         return Template::raw($this->getSrcsetFromArray($subset, $dpr));
     }
@@ -222,7 +222,7 @@ class OptimizedImage extends Model
      */
     public function srcsetMaxWidth(int $width, bool $dpr = false): string
     {
-        $subset = $this->getSrcsetSubsetArray($this->optimizedImageUrls, $width, 'maxwidth');
+        $subset = $this->getSrcsetSubsetArray($this->optimizedImageUrls, $width, 'maxwidth', $dpr);
 
         return Template::raw($this->getSrcsetFromArray($subset, $dpr));
     }
@@ -292,7 +292,7 @@ class OptimizedImage extends Model
      */
     public function srcsetWidthWebp(int $width, bool $dpr = false): string
     {
-        $subset = $this->getSrcsetSubsetArray($this->optimizedWebPImageUrls, $width, 'width');
+        $subset = $this->getSrcsetSubsetArray($this->optimizedWebPImageUrls, $width, 'width', $dpr);
 
         return Template::raw($this->getSrcsetFromArray($subset, $dpr));
     }
@@ -309,7 +309,7 @@ class OptimizedImage extends Model
      */
     public function srcsetMinWidthWebp(int $width, bool $dpr = false): string
     {
-        $subset = $this->getSrcsetSubsetArray($this->optimizedWebPImageUrls, $width, 'minwidth');
+        $subset = $this->getSrcsetSubsetArray($this->optimizedWebPImageUrls, $width, 'minwidth', $dpr);
 
         return Template::raw($this->getSrcsetFromArray($subset, $dpr));
     }
@@ -326,7 +326,7 @@ class OptimizedImage extends Model
      */
     public function srcsetMaxWidthWebp(int $width, bool $dpr = false): string
     {
-        $subset = $this->getSrcsetSubsetArray($this->optimizedWebPImageUrls, $width, 'maxwidth');
+        $subset = $this->getSrcsetSubsetArray($this->optimizedWebPImageUrls, $width, 'maxwidth', $dpr);
 
         return Template::raw($this->getSrcsetFromArray($subset, $dpr));
     }
@@ -611,42 +611,63 @@ class OptimizedImage extends Model
     // Protected Methods
     // =========================================================================
 
-    protected function getSrcsetSubsetArray(array $set, int $width, string $comparison): array
+    protected function getSrcsetSubsetArray(array $set, int $width, string $comparison, bool $dpr = false): array
     {
         $subset = [];
-        $index = 0;
         if (empty($this->variantSourceWidths)) {
             return $subset;
         }
-        // Sort the arrays by numeric key
-        ksort($set, SORT_NUMERIC);
-        // Sort the arrays by numeric key
-        sort($this->variantSourceWidths, SORT_NUMERIC);
-        foreach ($this->variantSourceWidths as $variantSourceWidth) {
+        
+        // For each actual width in the set, check if its source width matches
+        foreach ($set as $actualWidth => $url) {
+            // Find which variantSourceWidth this actualWidth belongs to
+            // Since retina variants are multiples (1x, 2x, 3x), we need to find the base width
+            $sourceWidth = null;
+            foreach (array_unique($this->variantSourceWidths) as $variantSourceWidth) {
+                // Check if actualWidth is 1x, 2x, or 3x of this variantSourceWidth
+                if ($actualWidth == $variantSourceWidth || 
+                    $actualWidth == $variantSourceWidth * 2 || 
+                    $actualWidth == $variantSourceWidth * 3) {
+                    $sourceWidth = $variantSourceWidth;
+                    break;
+                }
+            }
+            
+            if ($sourceWidth === null) {
+                continue;
+            }
+            
+            // Now check if this sourceWidth matches our comparison criteria
             $match = false;
             switch ($comparison) {
                 case 'width':
-                    if ($variantSourceWidth == $width) {
+                    if ($sourceWidth == $width) {
                         $match = true;
                     }
                     break;
 
                 case 'minwidth':
-                    if ($variantSourceWidth >= $width) {
+                    if ($sourceWidth >= $width) {
                         $match = true;
                     }
                     break;
 
                 case 'maxwidth':
-                    if ($variantSourceWidth <= $width) {
+                    if ($sourceWidth <= $width) {
                         $match = true;
                     }
                     break;
             }
+            
             if ($match) {
-                $subset += array_slice($set, $index, 1, true);
+                // When DPR mode is disabled (using 'w' descriptors), only include 1x variants
+                // When DPR mode is enabled (using 'x' descriptors), include all retina variants
+                if (!$dpr && $actualWidth != $sourceWidth) {
+                    // Skip retina variants (2x, 3x) when not in DPR mode
+                    continue;
+                }
+                $subset[$actualWidth] = $url;
             }
-            $index++;
         }
 
         return $subset;


### PR DESCRIPTION
### Description
The `getSrcsetSubsetArray()` method fails when retina variants (2x, 3x) are configured, causing `srcsetWidth()`, `srcsetWidthWebP()`, and related methods to return wrong variants.

Index-based mapping between `variantSourceWidths` (duplicated for retina) and sorted `optimizedImageUrls` keys breaks when looking up variants.

### Implemented Fix
Replace fragile index mapping with direct width analysis:
1. Iterate through actual widths in the URL set
2. Detect source width by checking retina multipliers (1x/2x/3x)
3. Filter based on source width comparisons
4. Add DPR parameter to control retina inclusion

### What's Been Tested
- ✅ All 6 methods: `srcsetWidth*()`, `srcsetMinWidth*()`, `srcsetMaxWidth*()`
- ✅ Both DPR modes: width descriptors (`w`) vs density descriptors (`x`)

**Configuration:** 5 base widths (360, 442, 466, 559, 573) × 2 retina variants = 10 total

#### Before Fix (Broken)
```twig
{{ optimizedImages.srcsetWidthWebP(559, true) }}
→ .../884px/...webp 1x, .../932px/...webp 1x  {# Wrong variants! #}
```

#### After Fix (Correct)
```twig
{{ optimizedImages.srcsetWidthWebP(559, true) }}
→ .../559px/...webp 1x, .../1118px/...webp 2x  {# Correct! #}

{{ optimizedImages.srcsetWidthWebP(559, false) }}
→ .../559px/...webp 559w                       {# Only 1x variant #}

{{ optimizedImages.srcsetMaxWidth(466, true) }}
→ 360px@1x, 720px@2x, 442px@1x, 884px@2x, 466px@1x, 932px@2x
```

##### Related Issues
- #431 
